### PR TITLE
Add debugger.h as c-source

### DIFF
--- a/hdb.cabal
+++ b/hdb.cabal
@@ -19,7 +19,8 @@ library
                  base,
                  containers
   extra-libraries: dw
-  c-sources: debugger.c 
+  c-sources: debugger.c,
+             debugger.h
   default-language: Haskell2010
   build-tools: hsc2hs
   include-dirs: .


### PR DESCRIPTION
This enables the project to be built on more recent versions of cabal (at least 3.6.2).